### PR TITLE
Default variable to false not empty string for puppet 4

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,7 +21,7 @@
 #
 # [*rvmrc*]
 #   Content for the global .rvmrc file placed in the user's homedir. If empty, .rvmrc will no be touched.
-#   Defaults to ''.
+#   Defaults to false.
 #
 # [*home*]
 #   Set to home directory of user. Defaults to /home/${user}.
@@ -75,8 +75,8 @@
 define single_user_rvm::install (
   $user         = $title,
   $version      = 'stable',
-  $rvmrc        = '',
-  $home         = '',
+  $rvmrc        = false,
+  $home         = false,
   $auto_upgrade = false,
 ) {
 

--- a/manifests/install_ruby.pp
+++ b/manifests/install_ruby.pp
@@ -51,9 +51,9 @@
 # [*user*]
 #   The user for which this Ruby will be installed. Defaults to 'rvm'.
 #
-# [*verify downloads*]
+# [*verify_downloads*]
 #   Set to a value that will be added to the --verify-downloads flag. If empty the whole flag will not be added. More
-#   info on the flag function in doc above. Defaults to ''.
+#   info on the flag function in doc above. Defaults to false.
 #
 # [*force_binary*]
 #   Set to true enable the --binary flag. More info on the flag function in doc above. Defaults to false.
@@ -78,7 +78,7 @@
 define single_user_rvm::install_ruby (
   $ruby_string      = $title,
   $user             = 'rvm',
-  $verify_downloads = '',
+  $verify_downloads = false,
   $force_binary     = false,
   $disable_binary   = false,
   $movable          = false,


### PR DESCRIPTION
Puppet 3 considered empty strings as false, in Puppet 4 they are correctly evaluated as true. This would alter the default logic of this module. Defaulting empty strings to false instead.